### PR TITLE
Add tests for force-sync algorithm

### DIFF
--- a/ntpd/src/force_sync/algorithm.rs
+++ b/ntpd/src/force_sync/algorithm.rs
@@ -116,6 +116,7 @@ impl<C: NtpClock> SingleShotController<C> {
             let avg_offset = NtpDuration::from_seconds(sum / (count as f64));
             self.offer_clock_change(avg_offset);
 
+            #[cfg(not(test))]
             std::process::exit(0);
         }
     }
@@ -238,5 +239,101 @@ where
 
     fn observe(&self) -> ntp_proto::ObservableSourceTimedata {
         ntp_proto::ObservableSourceTimedata::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ntp_proto::{NtpInstant, NtpLeapIndicator, NtpTimestamp, SynchronizationConfig};
+
+    #[derive(Debug, Clone, Default)]
+    struct TestClock;
+
+    impl NtpClock for TestClock {
+        type Error = std::convert::Infallible;
+
+        fn now(&self) -> Result<NtpTimestamp, Self::Error> {
+            Ok(NtpTimestamp::from_seconds_nanos_since_ntp_era(0, 0))
+        }
+
+        fn set_frequency(&self, _freq: f64) -> Result<NtpTimestamp, Self::Error> {
+            self.now()
+        }
+
+        fn get_frequency(&self) -> Result<f64, Self::Error> {
+            Ok(0.0)
+        }
+
+        fn step_clock(&self, _offset: NtpDuration) -> Result<NtpTimestamp, Self::Error> {
+            self.now()
+        }
+
+        fn disable_ntp_algorithm(&self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn error_estimate_update(
+            &self,
+            _est_error: NtpDuration,
+            _max_error: NtpDuration,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn status_update(&self, _leap_status: NtpLeapIndicator) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn measurement(offset: f64) -> Measurement<NtpDuration> {
+        Measurement {
+            delay: NtpDuration::ZERO,
+            offset: NtpDuration::from_seconds(offset),
+            localtime: NtpTimestamp::from_seconds_nanos_since_ntp_era(0, 0),
+            monotime: NtpInstant::now(),
+            stratum: 0,
+            root_delay: NtpDuration::ZERO,
+            root_dispersion: NtpDuration::ZERO,
+            leap: NtpLeapIndicator::NoWarning,
+            precision: 0,
+        }
+    }
+
+    fn controller() -> SingleShotController<TestClock> {
+        SingleShotController::new(
+            TestClock::default(),
+            SynchronizationConfig {
+                minimum_agreeing_sources: 2,
+                ..Default::default()
+            },
+            SingleShotControllerConfig {
+                expected_sources: 2,
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn does_not_step_without_agreement() {
+        super::super::reset_offered_offset();
+        let mut ctrl = controller();
+
+        ctrl.source_message(SourceId::new(), Measurements::Ntp(measurement(0.0)));
+        ctrl.source_message(SourceId::new(), Measurements::Ntp(measurement(10.0)));
+
+        assert!(super::super::offered_offset().is_none());
+    }
+
+    #[test]
+    fn steps_when_sources_agree() {
+        super::super::reset_offered_offset();
+        let mut ctrl = controller();
+
+        ctrl.source_message(SourceId::new(), Measurements::Ntp(measurement(1.0)));
+        ctrl.source_message(SourceId::new(), Measurements::Ntp(measurement(1.2)));
+
+        let offset = super::super::offered_offset().expect("offset expected");
+        assert!((offset.to_seconds() - 1.1).abs() < 1e-6);
     }
 }

--- a/ntpd/src/force_sync/mod.rs
+++ b/ntpd/src/force_sync/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(not(test))]
+use std::io::Write;
 use std::{
-    io::{IsTerminal, Write},
+    io::IsTerminal,
     path::PathBuf,
     process::ExitCode,
     time::{SystemTime, UNIX_EPOCH},
@@ -7,6 +9,8 @@ use std::{
 
 use algorithm::{SingleShotController, SingleShotControllerConfig};
 use ntp_proto::{NtpClock, NtpDuration};
+#[cfg(test)]
+use std::sync::Mutex;
 use tokio::runtime::Builder;
 
 use crate::daemon::{
@@ -14,6 +18,9 @@ use crate::daemon::{
 };
 
 mod algorithm;
+
+#[cfg(test)]
+static OFFERED_OFFSET: Mutex<Option<NtpDuration>> = Mutex::new(None);
 
 fn human_readable_duration(abs_offset: f64) -> String {
     let mut offset = abs_offset;
@@ -66,6 +73,7 @@ fn try_date_display(offset: NtpDuration) -> Option<String> {
         })
 }
 
+#[cfg(not(test))]
 impl<C: NtpClock> SingleShotController<C> {
     fn offer_clock_change(&self, offset: NtpDuration) {
         let offset_ms = offset.to_seconds();
@@ -107,6 +115,23 @@ impl<C: NtpClock> SingleShotController<C> {
             println!("Time not updated");
         }
     }
+}
+
+#[cfg(test)]
+impl<C: NtpClock> SingleShotController<C> {
+    fn offer_clock_change(&self, offset: NtpDuration) {
+        *OFFERED_OFFSET.lock().unwrap() = Some(offset);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn offered_offset() -> Option<NtpDuration> {
+    *OFFERED_OFFSET.lock().unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn reset_offered_offset() {
+    *OFFERED_OFFSET.lock().unwrap() = None;
 }
 
 pub(crate) fn force_sync(config: Option<PathBuf>) -> std::io::Result<ExitCode> {


### PR DESCRIPTION
## Summary
- enable SingleShotController testing by avoiding process exit and capturing proposed offset
- add unit tests covering force-sync offset consensus and disagreement cases

## Testing
- `cargo test --workspace --quiet`
- `cargo test -p ntpd --quiet`


------
https://chatgpt.com/codex/tasks/task_e_689f1d53be948326b3ad620947428aee